### PR TITLE
[major change] do not treat the path the app uses as the path of the file

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,18 @@ For example:
 ```json
     "config": {
         "asset": {
-            "sourcePath": "web",
-            "targetPath": "dist",
-            "files": ["/js/main.js", "/css/main.css"]
+            "/js/main.js": {"from": "frontend/src", "to": "frontend/dist"},
+            "/css/main.css": {"from": "web/css", "to": "web/css"}
         }
     },
     "scripts": {
         "build": "EasyBib\\Asset::run"
     },
+```
+
+The `config.asset` syntax is as follows:
+```
+    "the name you call Asset::path() with" => {from: "source directory", to: "target directory"}
 ```
 
 You can choose other script names, of course. Composer also has some [magic


### PR DESCRIPTION
With this change, it's possible for the app to refer to, say /js/main.js
without there being a /js directory anywhere.

In other words: where the file is read from, and where the hash-prefixed
file is written to is now completely independent from the path of the
file that the app uses.

I will tag this as 2.0