### PR TITLE
fix missing directory when using the prefixed file

### DIFF
--- a/src/EasyBib/Asset.php
+++ b/src/EasyBib/Asset.php
@@ -133,6 +133,6 @@ class Asset
             $filename
         );
         copy($sourcePath . '/' . $filename, $targetPath . '/' . $prefixedName);
-        return $prefixedName;
+        return dirname($nameUsedByApp) . '/' . $prefixedName;
     }
 }


### PR DESCRIPTION
the bug was that if you use

```php
<script src="<?php echo \EasyBib\Asset::path('/js/main.js`); ?>"
```

you'll get 
```html
<script src="68b329da9893e34099c7d8ad5cb9c940-main.js">
```

instead of
```html
<script src="/js/68b329da9893e34099c7d8ad5cb9c940-main.js">
```